### PR TITLE
feat: add SignWriting transforms (encode-only)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,6 @@
+/* SignWriting font (Google Fonts CDN) — only loads for ISWA codepoints via unicode-range */
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SignWriting&display=swap');
+
 .danger-modal-backdrop { display: none; }
 .danger-modal-backdrop.danger-active { display: none; }
 .danger-modal { display: none; }
@@ -49,6 +52,8 @@
     --randomizer-color-rgb: 156, 39, 176;
     --case-color: #9575cd;          /* Indigo for case transformations */
     --case-color-rgb: 149, 117, 205;
+    --signwriting-color: #e6a23c;    /* Warm amber for SignWriting */
+    --signwriting-color-rgb: 230, 162, 60;
     
     /* Active state gradient end colors */
     --encoding-active-end: #9575cd;
@@ -62,6 +67,7 @@
     --technical-active-end: #26c6da;
     --randomizer-active-end: #ab47bc;
     --case-active-end: #b39ddb;
+    --signwriting-active-end: #f0c96e;
     
     /* Spacing scale */
     --spacing-xs: 4px;
@@ -2603,6 +2609,15 @@ button.endsequence-item:hover .endsequence-copy-affordance {
 
 .transform-category-case .transform-preview {
     color: rgba(var(--case-color-rgb), 0.9);
+}
+
+.transform-category-signwriting .transform-preview {
+    color: rgba(var(--signwriting-color-rgb), 0.9);
+    font-family: 'Noto Sans SignWriting', 'Fira Code', monospace;
+}
+
+.output-container textarea {
+    font-family: 'Noto Sans SignWriting', 'Fira Code', 'Courier New', monospace;
 }
 
 .transform-button:hover .transform-preview {

--- a/src/transformers/signwriting/asl-signwriting.js
+++ b/src/transformers/signwriting/asl-signwriting.js
@@ -1,0 +1,99 @@
+// ASL SignWriting transform
+import BaseTransformer from '../BaseTransformer.js';
+
+export default new BaseTransformer({
+    name: 'ASL SignWriting',
+    priority: 0,
+    canDecode: false,
+    description: 'American Sign Language fingerspelling in SignWriting (ISWA 2010). Horizontal or vertical layout.',
+    configurableOptions: [
+        {
+            id: 'layout',
+            label: 'Layout',
+            type: 'select',
+            default: 'horizontal',
+            options: [
+                { label: 'Horizontal', value: 'horizontal' },
+                { label: 'Vertical', value: 'vertical' }
+            ]
+        }
+    ],
+
+    THIN: '\u2004',
+    NBSP: '\u00A0',
+
+    aslMap: {
+        'A': '𝣷𝪜', 'B': '𝡇𝪜', 'C': '𝡭𝪜', 'D': '𝠁𝪜', 'E': '𝡊𝪜',
+        'F': '𝣎𝪜', 'G': '𝣰', 'H': '𝠕𝪢', 'I': '𝢒𝪜',
+        'J': '𝦢𝪬\n𝢒𝪜', 'K': '𝡀𝪜', 'L': '𝣜𝪜', 'M': '𝢍𝪜',
+        'N': '𝠙𝪜', 'O': '𝡶𝪜', 'P': '𝡀𝪜𝪡', 'Q': '𝣱𝪜𝪡',
+        'R': '𝠚𝪜', 'S': '𝤃𝪜', 'T': '𝣻𝪜', 'U': '𝠕𝪜',
+        'V': '𝠎𝪜', 'W': '𝢇𝪜', 'X': '𝠆𝪜', 'Y': '𝢚𝪜',
+        'Z': '\u2004𝥅𝪪\n𝠀𝪜',
+        '.': '𝪈𝪢', ',': '𝪇𝪢', ':': '𝪊𝪢', ';': '𝪉𝪢',
+        '(': '𝪋𝪢', ')': '𝪋𝪦', '?': '𝦟𝪝𝪬\n𝠀𝪜',
+        '0': '𝡶𝪜', '1': '𝠀𝪜', '2': '𝠎𝪜', '3': '𝠞𝪜',
+        '4': '𝡄𝪜', '5': '𝡌𝪜', '6': '𝢇𝪜', '7': '𝢥𝪜',
+        '8': '𝢻𝪜', '9': '𝣎𝪜'
+    },
+
+    func: function(text, options) {
+        var layout = (options && options.layout) || 'horizontal';
+        text = text.toUpperCase();
+
+        if (layout === 'vertical') {
+            var words = text.split(/\s+/);
+            var wordBlocks = [];
+            for (var w = 0; w < words.length; w++) {
+                var chars = [];
+                for (var c = 0; c < words[w].length; c++) {
+                    var val = this.aslMap[words[w][c]];
+                    if (val !== undefined) chars.push(val);
+                }
+                wordBlocks.push(chars.join('\n\n'));
+            }
+            return wordBlocks.join('\n\n\n');
+        }
+
+        // Horizontal layout
+        var SPACE_TOKEN = this.NBSP + this.NBSP;
+        var signs = [];
+        for (var i = 0; i < text.length; i++) {
+            var ch = text[i];
+            if (ch === ' ') {
+                signs.push([SPACE_TOKEN]);
+            } else {
+                var val = this.aslMap[ch];
+                if (val !== undefined) {
+                    signs.push(val.split('\n'));
+                } else {
+                    signs.push([ch]);
+                }
+            }
+        }
+
+        var maxH = 1;
+        for (var s = 0; s < signs.length; s++) {
+            if (signs[s].length > maxH) maxH = signs[s].length;
+        }
+
+        var lanes = [];
+        for (var r = 0; r < maxH; r++) lanes.push('');
+
+        for (var s = 0; s < signs.length; s++) {
+            var padCount = maxH - signs[s].length;
+            var padded = [];
+            for (var p = 0; p < padCount; p++) padded.push(this.NBSP);
+            for (var p = 0; p < signs[s].length; p++) padded.push(signs[s][p]);
+            for (var r = 0; r < maxH; r++) {
+                lanes[r] += padded[r];
+            }
+        }
+        return lanes.join('\n');
+    },
+
+    preview: function(text) {
+        if (!text) return '[ASL SignWriting]';
+        return this.func(text.slice(0, 5));
+    }
+});

--- a/src/transformers/signwriting/ipa-lipreading.js
+++ b/src/transformers/signwriting/ipa-lipreading.js
@@ -1,0 +1,70 @@
+// IPA Lip-Reading SignWriting transform
+import BaseTransformer from '../BaseTransformer.js';
+
+export default new BaseTransformer({
+    name: 'IPA Lip-Reading',
+    priority: 0,
+    canDecode: false,
+    description: 'Converts IPA phonetic text to SignWriting lip-reading mouth shapes (ISWA 2010 head/face symbols).',
+
+    HEAD: '𝧿', EYE: '𝨔',
+
+    ipaToSw: {
+        'p': '𝩓𝨵', 'b': '𝩓𝨮', 'm': '𝩓𝨳',
+        'ɓ': '𝩓𝨮', 'ʙ': '𝩓𝨮', 'ɸ': '𝩓𝨵𝪛', 'β': '𝩓𝨮',
+        'f': '𝩥𝨵', 'v': '𝩥𝨮', 'ʋ': '𝩥𝨮', 'ɱ': '𝩥𝨳',
+        'θ': '𝩛𝨵', 'ð': '𝩛𝨮',
+        't': '𝩜𝨵', 'd': '𝩜𝨮', 'n': '𝩜𝨳',
+        's': '𝩀𝨵𝪛', 'z': '𝩀𝨮', 'l': '𝩜𝪤', 'r': '𝩟', 'ɾ': '𝩟', 'ɹ': '𝩟', 'ɻ': '𝩟',
+        'ʃ': '𝩍𝨵𝪛', 'ʒ': '𝩍𝨮',
+        'c': '𝩀𝨵', 'ɟ': '𝩀𝨮', 'ɲ': '𝩀𝨳', 'ç': '𝩀𝨵𝪛', 'ʝ': '𝩀𝨮', 'j': '𝩀', 'ʎ': '𝩀',
+        'k': '𝩄𝨵', 'g': '𝩄𝨮', 'ŋ': '𝩄𝨳', 'x': '𝩄𝨵𝪛', 'ɣ': '𝩄𝨮', 'w': '𝩆', 'ʍ': '𝩆',
+        'q': '𝩉𝨵', 'ɢ': '𝩉𝨮', 'ɴ': '𝩉𝨳', 'χ': '𝩉𝨵𝪛', 'ʁ': '𝩉𝨮', 'ʀ': '𝩉𝨮',
+        'ʕ': '𝩌𝨮', 'ħ': '𝩌𝨮', 'ʔ': '𝩡', 'h': '𝩄𝨵𝪛', 'ɦ': '𝩄𝨵𝪛',
+        'i': '𝩀', 'y': '𝩆', 'ɨ': '𝩀', 'ʉ': '𝩆', 'ɯ': '𝩐', 'u': '𝩆',
+        'ɪ': '𝩊', 'ʏ': '𝩇', 'ʊ': '𝩇',
+        'e': '𝩊', 'ø': '𝩇', 'ɘ': '𝩊', 'ɵ': '𝩇', 'ɤ': '𝩊', 'o': '𝩇', 'ə': '𝩊', 'ɚ': '𝩊',
+        'ɛ': '𝩈', 'œ': '𝩈', 'ɜ': '𝩈', 'ɞ': '𝩈', 'ʌ': '𝩉', 'ɔ': '𝩉',
+        'a': '𝩌', 'ɶ': '𝩌', 'ä': '𝩌', 'ɑ': '𝩌', 'ɒ': '𝩌', 'æ': '𝩌', 'ɐ': '𝩌',
+        'ʘ': '𝩓𝨶', 'ǀ': '𝩣𝨶', 'ǃ': '𝩡𝨶', 'ǂ': '𝩡𝨶', 'ǁ': '𝩡𝨶'
+    },
+
+    diphthongs: {
+        'aɪ': ['𝩌', '𝩀'], 'aʊ': ['𝩌', '𝩆'], 'eɪ': ['𝩊', '𝩀'],
+        'oʊ': ['𝩇', '𝩆'], 'ɔɪ': ['𝩉', '𝩀'], 'əʊ': ['𝩊', '𝩆'],
+        'ɪə': ['𝩊', '𝩊'], 'eə': ['𝩊', '𝩌'], 'ʊə': ['𝩇', '𝩊']
+    },
+
+    skipChars: { 'ˈ': 1, 'ˌ': 1, 'ː': 1, ' ': 1, '\t': 1, '\n': 1 },
+
+    func: function(text) {
+        var result = [], i = 0, HEAD = this.HEAD, EYE = this.EYE;
+        while (i < text.length) {
+            if (this.skipChars[text[i]]) { i++; continue; }
+            // Check diphthongs (2-char)
+            if (i + 1 < text.length) {
+                var di = text[i] + text[i + 1];
+                if (this.diphthongs[di]) {
+                    var shapes = this.diphthongs[di];
+                    for (var s = 0; s < shapes.length; s++) {
+                        result.push(HEAD + EYE + shapes[s]);
+                        if (s < shapes.length - 1) result.push('\u2192');
+                    }
+                    i += 2; continue;
+                }
+            }
+            var ch = text[i]; i++;
+            if (this.ipaToSw[ch]) {
+                result.push(HEAD + EYE + this.ipaToSw[ch]);
+            } else {
+                result.push(HEAD + EYE + '𝨻');
+            }
+        }
+        return result.join(' ');
+    },
+
+    preview: function(text) {
+        if (!text) return '[IPA Lip-Reading]';
+        return this.func(text.slice(0, 8));
+    }
+});

--- a/src/transformers/signwriting/jsl-signwriting.js
+++ b/src/transformers/signwriting/jsl-signwriting.js
@@ -1,0 +1,94 @@
+// JSL SignWriting transform
+import BaseTransformer from '../BaseTransformer.js';
+
+export default new BaseTransformer({
+    name: 'JSL SignWriting',
+    priority: 0,
+    canDecode: false,
+    description: 'Japanese Sign Language fingerspelling in SignWriting (ISWA 2010). Hiragana input.',
+    configurableOptions: [
+        { id: 'layout', label: 'Layout', type: 'select', default: 'horizontal',
+          options: [{ label: 'Horizontal', value: 'horizontal' }, { label: 'Vertical', value: 'vertical' }] }
+    ],
+    NBSP: '\u00A0',
+    SEP: '\u2001',
+    jslMap: {
+        'あ': ['𝣷𝪜'], 'ぁ': ['𝥥𝪤', '𝣷𝪜'], 'い': ['𝢒𝪜'], 'ぃ': ['𝥥𝪤', '𝢒𝪜'],
+        'う': ['𝠕𝪜'], 'ぅ': ['𝥥𝪤', '𝠕𝪜'], 'え': ['𝡦𝪜'], 'ぇ': ['𝥥𝪤', '𝡦𝪜'],
+        'お': ['𝡶𝪛'], 'ぉ': ['𝥥𝪤', '𝡶𝪛'], 'か': ['𝡀𝪜'], 'ゕ': ['𝥥𝪤', '𝡀𝪜'],
+        'き': ['𝣮𝪜𝪦'], 'く': ['𝡝𝪢'], 'け': ['𝡇𝪜'], 'ゖ': ['𝥥𝪤', '𝡇𝪜'],
+        'こ': ['𝢀𝪛'], 'さ': ['𝤃𝪜'], 'し': ['𝠞𝪢'], 'す': ['𝠞𝪤'], 'せ': ['𝣆𝪜'], 'そ': ['𝠀𝪞'],
+        'た': ['𝣷𝪞'], 'ち': ['𝢖𝪜'], 'つ': ['𝢳𝪜'], 'っ': ['𝥥𝪤', '𝢳𝪜'],
+        'て': ['𝡌𝪜'], 'と': ['𝠕'], 'な': ['𝠎𝪤'], 'に': ['𝠎𝪢'], 'ぬ': ['𝠆𝪛'], 'ね': ['𝡌𝪤'],
+        'の': ['𝤪𝪣', '𝠀𝪛'], 'は': ['𝠕𝪞'], 'ひ': ['𝠀𝪜'], 'ふ': ['𝣰𝪟𝪡'], 'へ': ['𝢚𝪟'], 'ほ': ['𝢀𝪝'],
+        'ま': ['𝢌𝪤'], 'み': ['𝢌𝪢'], 'む': ['𝣜𝪢'], 'め': ['𝣎𝪜'], 'も': ['𝤪𝪤', '𝤜𝣴𝪝𝪦'],
+        'や': ['𝢚𝪜'], 'ゃ': ['𝥥𝪤', '𝢚𝪜'], 'ゆ': ['𝢌'], 'ゅ': ['𝥥𝪤', '𝢌'],
+        'よ': ['𝡄𝪢'], 'ょ': ['𝥥𝪤', '𝡄𝪢'], 'ら': ['𝠚𝪜'], 'り': ['𝦢𝪬', '𝠎𝪞'], 'る': ['𝠞𝪜'],
+        'れ': ['𝣜𝪜'], 'ろ': ['𝠐𝪛'], 'わ': ['𝢆𝪜'], 'ゎ': ['𝥥𝪤', '𝢆𝪜'],
+        'ゐ': ['𝥥𝪤', '𝢒𝪜'], 'ゑ': ['𝥥𝪤', '𝡦𝪜'], 'を': ['𝥥𝪤', '𝡶𝪛'],
+        'ん': ['𝦢𝪤', '𝠀𝪞'],
+        'が': ['𝡀𝪜𝥥𝪦'], 'ぎ': ['𝣮𝪜𝪦𝥥𝪦'], 'ぐ': ['𝡝𝪢𝥥𝪦'], 'げ': ['𝡇𝪜𝥥𝪦'], 'ご': ['𝢀𝪛𝥥𝪦'],
+        'ざ': ['𝤃𝪜𝥥𝪦'], 'じ': ['𝠞𝪢𝥥𝪦'], 'ず': ['𝠞𝪤𝥥𝪦'], 'ぜ': ['𝣆𝪜𝥥𝪦'], 'ぞ': ['𝠀𝪞𝥥𝪦'],
+        'だ': ['𝣷𝪞𝥥𝪦'], 'ぢ': ['𝢖𝪜𝥥𝪦'], 'づ': ['𝢳𝪜𝥥𝪦'], 'で': ['𝡌𝪜𝥥𝪦'], 'ど': ['𝠕𝥥𝪦'],
+        'ば': ['𝠕𝪞𝥥𝪦'], 'び': ['𝠀𝪜𝥥𝪦'], 'ぶ': ['𝣰𝪟𝪡𝥥𝪦'], 'べ': ['𝢚𝪟𝥥𝪦'], 'ぼ': ['𝢀𝪝𝥥𝪦'],
+        'ぱ': ['𝤪', '𝠕𝪞'], 'ぴ': ['𝤪', '𝠀𝪜'], 'ぷ': ['𝤪', '𝣰𝪟𝪡'], 'ぺ': ['𝤪', '𝢚𝪟'], 'ぽ': ['𝤪', '𝢀𝪝'],
+        'ー': ['𝥥𝪤'],
+        '0': ['𝠊𝪛'], '1': ['𝠀𝪜'], '2': ['𝠎𝪜'], '3': ['𝢆𝪜'], '4': ['𝡄𝪜'],
+        '5': ['𝣷𝪜'], '6': ['𝣜𝪢'], '7': ['𝠞𝪢'], '8': ['𝢎𝪢'], '9': ['𝡝𝪢'],
+        ' ': ['\u00A0']
+    },
+    jslDigraph: {
+        'きゃ': ['𝣮𝪜𝪦', '𝥥𝪤', '𝢚𝪜'], 'きゅ': ['𝣮𝪜𝪦', '𝥥𝪤', '𝢌'], 'きょ': ['𝣮𝪜𝪦', '𝥥𝪤', '𝡄𝪢'],
+        'しゃ': ['𝠞𝪢', '𝥥𝪤', '𝢚𝪜'], 'しゅ': ['𝠞𝪢', '𝥥𝪤', '𝢌'], 'しょ': ['𝠞𝪢', '𝥥𝪤', '𝡄𝪢'],
+        'ちゃ': ['𝢖𝪜', '𝥥𝪤', '𝢚𝪜'], 'ちゅ': ['𝢖𝪜', '𝥥𝪤', '𝢌'], 'ちょ': ['𝢖𝪜', '𝥥𝪤', '𝡄𝪢'],
+        'にゃ': ['𝠎𝪢', '𝥥𝪤', '𝢚𝪜'], 'にゅ': ['𝠎𝪢', '𝥥𝪤', '𝢌'], 'にょ': ['𝠎𝪢', '𝥥𝪤', '𝡄𝪢'],
+        'ひゃ': ['𝠀𝪜', '𝥥𝪤', '𝢚𝪜'], 'ひゅ': ['𝠀𝪜', '𝥥𝪤', '𝢌'], 'ひょ': ['𝠀𝪜', '𝥥𝪤', '𝡄𝪢'],
+        'みゃ': ['𝢌𝪢', '𝥥𝪤', '𝢚𝪜'], 'みゅ': ['𝢌𝪢', '𝥥𝪤', '𝢌'], 'みょ': ['𝢌𝪢', '𝥥𝪤', '𝡄𝪢'],
+        'りゃ': ['𝦢𝪬', '𝠎𝪞', '𝥥𝪤', '𝢚𝪜'], 'りゅ': ['𝦢𝪬', '𝠎𝪞', '𝥥𝪤', '𝢌'],
+        'りょ': ['𝦢𝪬', '𝠎𝪞', '𝥥𝪤', '𝡄𝪢'],
+        'ぎゃ': ['𝣮𝪜𝪦𝥥𝪦', '𝥥𝪤', '𝢚𝪜'], 'ぎゅ': ['𝣮𝪜𝪦𝥥𝪦', '𝥥𝪤', '𝢌'],
+        'ぎょ': ['𝣮𝪜𝪦𝥥𝪦', '𝥥𝪤', '𝡄𝪢'],
+        'じゃ': ['𝠞𝪢𝥥𝪦', '𝥥𝪤', '𝢚𝪜'], 'じゅ': ['𝠞𝪢𝥥𝪦', '𝥥𝪤', '𝢌'],
+        'じょ': ['𝠞𝪢𝥥𝪦', '𝥥𝪤', '𝡄𝪢'],
+        'ぴゃ': ['𝤪', '𝠀𝪜', '𝥥𝪤', '𝢚𝪜'], 'ぴゅ': ['𝤪', '𝠀𝪜', '𝥥𝪤', '𝢌'],
+        'ぴょ': ['𝤪', '𝠀𝪜', '𝥥𝪤', '𝡄𝪢']
+    },
+    tokenize: function(text) {
+        var out = [], i = 0;
+        while (i < text.length) {
+            if (i + 1 < text.length && this.jslDigraph[text[i] + text[i + 1]]) {
+                out.push(this.jslDigraph[text[i] + text[i + 1]]); i += 2;
+            } else {
+                out.push(this.jslMap[text[i]] || [text[i]]); i++;
+            }
+        }
+        return out;
+    },
+    func: function(text, options) {
+        var layout = (options && options.layout) || 'horizontal';
+        if (layout === 'vertical') {
+            var words = text.split(/\s+/), wb = [];
+            for (var w = 0; w < words.length; w++) {
+                var tok = this.tokenize(words[w]), cb = [];
+                for (var t = 0; t < tok.length; t++) cb.push(tok[t].join('\n'));
+                wb.push(cb.join('\n\n'));
+            }
+            return wb.join('\n\n\n');
+        }
+        var tokens = this.tokenize(text), maxH = 1;
+        for (var t = 0; t < tokens.length; t++) if (tokens[t].length > maxH) maxH = tokens[t].length;
+        var lanes = [];
+        for (var r = 0; r < maxH; r++) lanes.push([]);
+        for (var t = 0; t < tokens.length; t++) {
+            var pad = maxH - tokens[t].length, padded = [];
+            for (var p = 0; p < pad; p++) padded.push('');
+            for (var p = 0; p < tokens[t].length; p++) padded.push(tokens[t][p]);
+            for (var r = 0; r < maxH; r++) lanes[r].push(padded[r] || this.NBSP);
+        }
+        return lanes.map(function(l) { return l.join('\u2001'); }).join('\n');
+    },
+    preview: function(text) {
+        if (!text) return '[JSL SignWriting]';
+        return this.func(text.slice(0, 5));
+    }
+});

--- a/src/transformers/signwriting/libras-signwriting.js
+++ b/src/transformers/signwriting/libras-signwriting.js
@@ -1,0 +1,116 @@
+// LIBRAS SignWriting transform
+import BaseTransformer from '../BaseTransformer.js';
+
+export default new BaseTransformer({
+    name: 'LIBRAS SignWriting',
+    priority: 0,
+    canDecode: false,
+    description: 'Brazilian Sign Language (Libras) fingerspelling in SignWriting (ISWA 2010). Horizontal or vertical layout.',
+    configurableOptions: [
+        {
+            id: 'layout',
+            label: 'Layout',
+            type: 'select',
+            default: 'horizontal',
+            options: [
+                { label: 'Horizontal', value: 'horizontal' },
+                { label: 'Vertical', value: 'vertical' }
+            ]
+        }
+    ],
+
+    NBSP: '\u00A0',
+
+    librasMap: {
+        'A': ['𝣷𝪜'], 'B': ['𝡇𝪜'], 'C': ['𝡭𝪜'],
+        'D': ['𝠁𝪜'], 'E': ['𝡊𝪜'],
+        'F': ['𝣒𝪜'], 'G': ['𝣟𝪜'], 'H': ['𝧟', '𝡀𝪜𝪧'],
+        'I': ['𝢒𝪜'], 'J': ['𝢒𝪟', '𝦢𝪬'], 'K': ['𝤮', '𝡀𝪜'],
+        'L': ['𝣜𝪜'], 'M': ['𝢍𝪜'], 'N': ['𝠙𝪜'],
+        'O': ['𝡶𝪜'], 'P': ['𝡀𝪟'], 'Q': ['𝣲𝪟'],
+        'R': ['𝠚𝪜'], 'S': ['𝤃𝪜'], 'T': ['𝣓𝪜'],
+        'U': ['𝠕𝪜'], 'V': ['𝠎𝪜'], 'W': ['𝢇𝪜'],
+        'X': ['𝠊𝪟', '𝥥𝪤'], 'Y': ['𝢚𝪜'],
+        'Z': ['\u2004𝥅𝪪', '𝠀𝪜'],
+        '0': ['𝡶𝪜'], '1': ['𝠀'], '2': ['𝠎'], '3': ['𝢆'],
+        '4': ['𝡄'], '5': ['𝠐𝪨'], '6': ['𝡴𝪝𝪮'],
+        '7': ['𝢃𝪛'], '8': ['𝧢𝪝', '𝤃𝪛'], '9': ['𝡵𝪟𝪢']
+    },
+
+    /**
+     * Strip diacritics from text (e.g. Ç → C, É → E)
+     */
+    stripDiacritics: function(text) {
+        // NFD decomposes, then remove combining marks
+        var decomposed = text.normalize('NFD');
+        var out = '';
+        for (var i = 0; i < decomposed.length; i++) {
+            // Combining Diacritical Marks block: U+0300–U+036F
+            var cp = decomposed.charCodeAt(i);
+            if (cp < 0x0300 || cp > 0x036F) {
+                out += decomposed[i];
+            }
+        }
+        return out;
+    },
+
+    func: function(text, options) {
+        var layout = (options && options.layout) || 'horizontal';
+        text = this.stripDiacritics(text).toUpperCase();
+
+        if (layout === 'vertical') {
+            var words = text.split(/\s+/);
+            var wordBlocks = [];
+            for (var w = 0; w < words.length; w++) {
+                var chars = [];
+                for (var c = 0; c < words[w].length; c++) {
+                    var sign = this.librasMap[words[w][c]];
+                    if (sign) chars.push(sign.join('\n'));
+                }
+                wordBlocks.push(chars.join('\n\n'));
+            }
+            return wordBlocks.join('\n\n\n');
+        }
+
+        // Horizontal layout
+        var SPACE_TOKEN = this.NBSP + this.NBSP;
+        var signs = [];
+        for (var i = 0; i < text.length; i++) {
+            var ch = text[i];
+            if (ch === ' ') {
+                signs.push([SPACE_TOKEN]);
+            } else {
+                var sign = this.librasMap[ch];
+                if (sign) {
+                    signs.push(sign.slice());
+                } else {
+                    signs.push([ch]);
+                }
+            }
+        }
+
+        var maxH = 1;
+        for (var s = 0; s < signs.length; s++) {
+            if (signs[s].length > maxH) maxH = signs[s].length;
+        }
+
+        var lanes = [];
+        for (var r = 0; r < maxH; r++) lanes.push('');
+
+        for (var s = 0; s < signs.length; s++) {
+            var padCount = maxH - signs[s].length;
+            var padded = [];
+            for (var p = 0; p < padCount; p++) padded.push(this.NBSP);
+            for (var p = 0; p < signs[s].length; p++) padded.push(signs[s][p]);
+            for (var r = 0; r < maxH; r++) {
+                lanes[r] += padded[r];
+            }
+        }
+        return lanes.join('\n');
+    },
+
+    preview: function(text) {
+        if (!text) return '[LIBRAS SignWriting]';
+        return this.func(text.slice(0, 5));
+    }
+});

--- a/src/transformers/signwriting/morse-blink.js
+++ b/src/transformers/signwriting/morse-blink.js
@@ -1,0 +1,48 @@
+// Morse Blink SignWriting transform
+import BaseTransformer from '../BaseTransformer.js';
+
+export default new BaseTransformer({
+    name: 'Morse Blink',
+    priority: 0,
+    canDecode: false,
+    description: 'Encodes text as Morse code using SignWriting eye blink symbols (dot = brief close, dash = tight press).',
+
+    DOT: '𝧿𝨕',   // Eye closes briefly
+    DASH: '𝧿𝨖',  // Eye pressed tightly
+    GAP: '𝧿𝨚',   // Eye open (delimiter)
+
+    morseMap: {
+        'A': '.-', 'B': '-...', 'C': '-.-.', 'D': '-..', 'E': '.', 'F': '..-.',
+        'G': '--.', 'H': '....', 'I': '..', 'J': '.---', 'K': '-.-', 'L': '.-..',
+        'M': '--', 'N': '-.', 'O': '---', 'P': '.--.', 'Q': '--.-', 'R': '.-.',
+        'S': '...', 'T': '-', 'U': '..-', 'V': '...-', 'W': '.--', 'X': '-..-',
+        'Y': '-.--', 'Z': '--..', '1': '.----', '2': '..---', '3': '...--',
+        '4': '....-', '5': '.....', '6': '-....', '7': '--...', '8': '---..',
+        '9': '----.', '0': '-----', ' ': '/'
+    },
+
+    func: function(text) {
+        var upper = text.toUpperCase();
+        var lines = [];
+        for (var i = 0; i < upper.length; i++) {
+            var ch = upper[i];
+            var code = this.morseMap[ch];
+            if (!code) continue;
+            if (code === '/') {
+                lines.push('');
+                continue;
+            }
+            var symbols = [];
+            for (var j = 0; j < code.length; j++) {
+                symbols.push(code[j] === '.' ? this.DOT : this.DASH);
+            }
+            lines.push(symbols.join(' ') + ' ' + this.GAP);
+        }
+        return lines.join('\n');
+    },
+
+    preview: function(text) {
+        if (!text) return '[Morse Blink]';
+        return this.func(text.slice(0, 3));
+    }
+});

--- a/src/transformers/signwriting/tactile-signwriting.js
+++ b/src/transformers/signwriting/tactile-signwriting.js
@@ -1,0 +1,60 @@
+// Deafblind Tactile SignWriting transform
+import BaseTransformer from '../BaseTransformer.js';
+
+export default new BaseTransformer({
+    name: 'Tactile SignWriting',
+    priority: 0,
+    canDecode: false,
+    description: 'Deafblind tactile fingerspelling approximation in SignWriting (ISWA 2010). Two-hand layers per letter.',
+
+    tactileMap: {
+        'A': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝣷𝪝𝪩𝪆𝪞𝤅'],
+        'B': ['𝡌𝪝𝪩𝡶𝪞', '𝡌𝪝𝪩𝪆𝪟𝤅'],
+        'C': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝣜𝪝𝪩𝪆𝪟𝪧𝤎𝤻𝪩'],
+        'D': ['𝡌𝪝𝪩𝣢𝪟𝪡', '𝠀𝪝𝪩𝪆𝪞𝪆𝪞𝪨𝤅'],
+        'E': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝠀𝪝𝪩𝪆𝪞𝤅'],
+        'F': ['𝡌𝪝𝪩𝠕𝪟𝪡', '𝠀𝪝𝪩𝪆𝪞𝪩𝤅'],
+        'G': ['𝡌𝪝𝪩𝤃𝪞𝪡', '𝡌𝪝𝪩𝪆𝪟𝤅'],
+        'H': ['𝡌𝪝𝪩𝡌𝪟𝪡', '𝡌𝪝𝪩𝤎𝥦𝪧'],
+        'I': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝣆𝪝𝪧𝪆𝪞𝤅'],
+        'J': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝡌𝪝𝪩𝣆𝪝𝪧𝪆𝪞𝤎𝥦𝪣𝪆𝪟𝥸𝪧'],
+        'K': ['𝡌𝪝𝪩𝠆𝪝𝪡', '𝠀𝪝𝪩𝪆𝪞𝪩𝤅'],
+        'L': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝡌𝪝𝪩𝪆𝪟𝤅'],
+        'M': ['𝡌𝪝𝪩𝢌𝪟𝪡', '𝡌𝪝𝪩𝪆𝪟𝤅'],
+        'N': ['𝡌𝪝𝪩𝠕𝪟𝪡', '𝡌𝪝𝪩𝪆𝪟𝤅'],
+        'O': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝢮𝪝𝪩𝪆𝪞𝤅'],
+        'P': ['𝡌𝪝𝪩𝣱𝪟𝪡', '𝠀𝪝𝪩𝪆𝪞𝪢𝤗'],
+        'Q': ['𝡌𝪝𝪩𝠆𝪟𝪡', '𝣷𝪝𝪩𝤈𝩾𝪡'],
+        'R': ['𝡌𝪝𝪩𝠆𝪞𝪡', '𝡌𝪝𝪩𝪆𝪟𝪫𝤅'],
+        'S': ['𝡌𝪝𝪩𝠆𝪟𝪡', '𝢒𝪝𝪩𝤈𝩾𝪡'],
+        'T': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝡌𝪝𝪩𝪆𝪟𝪫𝤅'],
+        'U': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝢒𝪝𝪩𝪆𝪞𝤅'],
+        'V': ['𝡌𝪝𝪩𝠎𝪟𝪡', '𝡌𝪝𝪩𝪆𝪟𝤅'],
+        'W': ['𝡌𝪝𝪩𝡎𝪟𝪡', '𝡝𝪝𝪩𝪆𝪟𝪡𝤈'],
+        'X': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝠀𝪝𝪩𝪆𝪞𝪩𝤅'],
+        'Y': ['𝡌𝪝𝪩𝠀𝪟𝪡', '𝣷𝪝𝪩𝪆𝪟𝪬'],
+        'Z': ['𝡌𝪝𝪩𝡚𝪞𝪡', '𝡌𝪝𝪩𝪆𝪟𝤅']
+    },
+
+    func: function(text) {
+        var upper = text.toUpperCase();
+        var blocks = [];
+        for (var i = 0; i < upper.length; i++) {
+            var ch = upper[i];
+            if (ch === ' ') {
+                blocks.push('\u00A0\n\u00A0');
+                continue;
+            }
+            var sign = this.tactileMap[ch];
+            if (sign) {
+                blocks.push(sign[0] + '\n' + sign[1]);
+            }
+        }
+        return blocks.join('\n\n');
+    },
+
+    preview: function(text) {
+        if (!text) return '[Tactile SignWriting]';
+        return this.func(text.slice(0, 3));
+    }
+});


### PR DESCRIPTION
Add 6 new SignWriting transforms under src/transformers/signwriting/:
- ASL SignWriting (American Sign Language fingerspelling)
- LIBRAS SignWriting (Brazilian Sign Language)
- JSL SignWriting (Japanese Sign Language, hiragana input)
- IPA Lip-Reading (IPA phonetic to mouth shapes)
- Morse Blink (Morse code via eye blink symbols)
- Tactile SignWriting (deafblind two-hand contact)

All support horizontal/vertical layout options where applicable.
Encode-only, no decode.

Bundle NotoSansSignWriting-Regular.ttf under css/fonts/ since
ISWA 2010 glyphs aren't in any standard system font. Font is
scoped to signwriting button previews and the output textarea
only when a signwriting transform is active.