### PR TITLE
fix: Morse Code produces empty output when clicked on the Transforms page

### DIFF
--- a/src/transformers/technical/morse.js
+++ b/src/transformers/technical/morse.js
@@ -34,7 +34,13 @@ export default new BaseTransformer({
             }
             return revMap;
         },
-        func: function(text, decode = false) {
+        // Second arg is the shared options object every other transform takes.
+        // It used to be a bare `decode` boolean, which silently broke encoding:
+        // the app always passes an options object, and `{}` is truthy, so every
+        // encode request ran as a decode and returned "". Accept both — `true`
+        // for the internal reverse() call, or `{ decode: true }` from options.
+        func: function(text, options) {
+            const decode = options === true || !!(options && options.decode === true);
             if (decode) {
                 // Decode mode
                 const revMap = this.reverseMap();
@@ -50,7 +56,7 @@ export default new BaseTransformer({
             }
         },
         preview: function(text) {
-            if (!text) return '[base32]';
+            if (!text) return '[morse]';
             const result = this.func(text.slice(0, 2));
             return result + '...';
         },


### PR DESCRIPTION
## Bug
Clicking "Morse Code" on the Transforms page copies an empty string instead
of the Morse-encoded text. No error is shown — the button just silently
produces nothing.
## Root cause
`morse.js`'s `func` took a bare `decode` boolean as its second argument:
```js
func: function(text, decode = false) {
    if (decode) { /* decode branch */ }
    else { /* encode branch */ }
}
```
Every other transform's `func` takes an options object, and the app always
passes one when a transform is applied
(`transform.func(this.transformInput, opts)` in `TransformTool.js`). An empty
object `{}` is truthy, so that call took the `decode` branch and returned
`""`.
### Why this was easy to miss
The transform button's own preview label looked correct. `preview()` calls
`this.func(text)` with a single argument, so `decode` was `undefined` there,
took the encode branch, and rendered real dots and dashes on the button. The
UI advertised working output for a transform that produced nothing when
actually clicked — the one place a user would notice is also the one place
the bug doesn't reproduce.
## Verification
Reproduced against a clean checkout, independent of any other changes:
1. Fresh clone of `elder-plinius/P4RS3LT0NGV3` (`origin` only, no forks), current `main`.
2. `npm install && npm run build` — no modifications.
3. Confirmed the buggy signature is present in the built bundle itself:
   `dist/js/bundles/transforms-bundle.js:12161: func: function(text, decode = false) {`
4. Served `dist/` and clicked the actual "Morse Code" button in the rendered
   UI with input `"Hello World"`.
5. Result: `transformOutput` was `""`, `activeTransform.name` was `"Morse
   Code"` (so the click registered), and the app's copy-history count stayed
   at `0` — the copy-to-clipboard call fired with nothing to copy.
With the fix applied, the same input/click produces:
`.... . .-.. .-.. --- / .-- --- .-. .-.. -..`
which decodes back to `hello world` via the existing `reverse()`.
## Fix
`func` now accepts both call shapes that exist in the codebase today:
- `true` — from the transform's own internal `reverse()` call
- `{ decode: true }` — the options-object shape every other transform uses
```js
func: function(text, options) {
    const decode = options === true || !!(options && options.decode === true);
    if (decode) { /* decode branch */ }
    else { /* encode branch */ }
}
```
Nothing that worked before this change behaves differently — `reverse()`
still passes `true` and still decodes; encode calls that pass an options
object now correctly encode instead of silently decoding-to-empty.
Also fixes the preview placeholder, which returned `'[base32]'` for an empty
input on the Morse transform (leftover copy-paste from another transformer).
## Test plan
- [ ] Enter text on the Transforms page, click "Morse Code" — output is the
      Morse-encoded text, not empty
- [ ] Confirm it's copied to the clipboard / appears in Copy History
- [ ] Paste the encoded output into the Decoder — it round-trips back to the
      original text
- [ ] Existing behavior unaffected: button preview label still renders
      correctly
## Diff
Single file: `src/transformers/technical/morse.js`. No other files touched.